### PR TITLE
[#5] Fixed authentication cache time, and added means to test it

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,15 @@
                 type: 'raster',
                 source: 'osm',
             }],
+        },
+        transformRequest: (url, resourceType) => {
+            return {
+                url: url,
+                // Add some basic authentication for testing, here 'user:password'.
+                headers: {'Authorization': "Basic dXNlcjpwYXNzd29yZA=="},
+            };
         }
+
     });
     document.getElementById("raster").addEventListener("change", (ev) => {
         if (ev.target.checked) {

--- a/src/auth_middleware.rs
+++ b/src/auth_middleware.rs
@@ -1,28 +1,30 @@
+use crate::app_conf::{AppState, AuthState};
+use crate::error::UnauthorizedAccess;
+use actix_web::body::{BoxBody, MessageBody};
+use actix_web::dev::{ServiceRequest, ServiceResponse};
+use actix_web::error::HttpError;
+use actix_web::middleware::{Logger, Next};
+use actix_web::web::{head, Data};
+use actix_web::{Error, HttpResponse};
+use log::{debug, log};
+use pyo3::impl_::wrap::SomeWrap;
+use pyo3::prelude::{PyAnyMethods, PyModule};
+use pyo3::types::IntoPyDict;
+use pyo3::Python;
+use pyo3_ffi::c_str;
 use std::ffi::CString;
 use std::fs;
 use std::ops::{Add, Not};
 use std::time::{Duration, Instant};
-use actix_web::body::{BoxBody, MessageBody};
-use actix_web::dev::{ServiceRequest, ServiceResponse};
-use actix_web::{Error, HttpResponse};
-use actix_web::error::HttpError;
-use actix_web::middleware::{Logger, Next};
-use actix_web::web::{head, Data};
-use pyo3::impl_::wrap::SomeWrap;
-use pyo3::prelude::{PyAnyMethods, PyModule};
-use pyo3::Python;
-use pyo3::types::IntoPyDict;
-use pyo3_ffi::c_str;
-use log::{debug, log};
-use crate::app_conf::{AppState, AuthState};
-use crate::error::UnauthorizedAccess;
 
 pub(crate) async fn auth_middleware(
     req: ServiceRequest,
     next: Next<impl MessageBody>,
 ) -> Result<ServiceResponse<impl MessageBody>, Error> {
     let mut is_allowed = false;
-    {
+    if req.method() == "OPTIONS" {
+        is_allowed = true;
+    } else {
         let app_data = req.app_data::<Data<AppState>>().unwrap();
         let script_text = CString::new(fs::read_to_string(app_data.auth_script.as_str()).unwrap());
         let req_path = req.path();
@@ -31,8 +33,7 @@ pub(crate) async fn auth_middleware(
         let mut auth_cache = app_data.auth_cache.lock().unwrap();
         let now = Instant::now();
         // Remove expired entries
-        auth_cache.retain(|k, v| v.exp_time > now );
-
+        auth_cache.retain(|k, v| v.exp_time > now);
 
         let mut user_session_hash = "".to_string();
         let mut headers = Vec::<(String, String)>::new();
@@ -41,13 +42,18 @@ pub(crate) async fn auth_middleware(
             let value = req.headers().get(header);
             if value.is_none() {
                 // One of the auth headers is not found so exit here with 401
-                return Err(Error::from(UnauthorizedAccess { name: "Unauthorized" }));
+                return Err(Error::from(UnauthorizedAccess {
+                    name: "Unauthorized",
+                }));
             } else {
                 // Header found so append to session hash
                 user_session_hash = String::new()
                     .add(user_session_hash.as_str())
                     .add(value.unwrap().to_str().unwrap());
-                headers.push((header.to_string(), value.unwrap().to_str().unwrap().to_string()));
+                headers.push((
+                    header.to_string(),
+                    value.unwrap().to_str().unwrap().to_string(),
+                ));
             }
         }
 
@@ -66,7 +72,10 @@ pub(crate) async fn auth_middleware(
             // Found session hash in the cache
             let auth_state = user_auth_state.unwrap();
             if now < auth_state.exp_time {
-                debug!("Cache hit for {}", user_session_hash);
+                debug!("Cache hit for {}..., valid for {} more seconds",
+                    user_session_hash.chars().take(8).collect::<String>(),
+                    auth_state.exp_time.duration_since(now).as_secs().to_string()
+                );
                 is_check_required = false;
                 is_allowed = auth_state.is_allowed;
             } else {
@@ -81,23 +90,38 @@ pub(crate) async fn auth_middleware(
                     py,
                     script_text.unwrap().as_c_str(),
                     c_str!("g_auth.py"),
-                    c_str!("g_auth")
+                    c_str!("g_auth"),
                 );
                 let kwargs = headers.into_py_dict(py).unwrap();
-                let auth_result: bool = callable.unwrap().getattr("auth")
-                    .unwrap().call((req_path,), Some(&kwargs))
-                    .unwrap().extract().unwrap();
+                let auth_result: bool = callable
+                    .unwrap()
+                    .getattr("auth")
+                    .unwrap()
+                    .call((req_path,), Some(&kwargs))
+                    .unwrap()
+                    .extract()
+                    .unwrap();
 
                 // Print and save result to cache
                 debug!("Result from auth script: {:?}", auth_result);
-                auth_cache.insert(user_session_hash.to_string(), AuthState { is_allowed: auth_result, exp_time: Instant::now().add(Duration::from_secs(60)) });
+
+                let cache_validity_s = app_data.cache_validity_seconds;
+                auth_cache.insert(
+                    user_session_hash.to_string(),
+                    AuthState {
+                        is_allowed: auth_result,
+                        exp_time: Instant::now().add(Duration::from_secs(cache_validity_s)),
+                    },
+                );
                 is_allowed = auth_result;
             });
         }
     }
 
     if !is_allowed {
-        return Err(Error::from(UnauthorizedAccess { name: "Unauthorized" }));
+        return Err(Error::from(UnauthorizedAccess {
+            name: "Unauthorized",
+        }));
     }
 
     // Proceed to serving

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,7 @@ async fn main() {
         .arg(arg!(--tilesmode [TILES_MODE] "The serving mode for MBTiles, either 'filesystem' or 'mbtiles'. The former assumes the tile data is stored directly as individual files, the latter assumes a flat directory of MBTiles files.").default_value("mbtiles"))
         .arg(arg!(--authscript [AUTH_SCRIPT] "Python script for authentication").default_value("auth.py"))
         .arg(arg!(--authheaders [AUTH_HEADERS] "Request headers with authorization data, if you need several of them use commas to separate").default_value(""))
-        .arg(arg!(--cachetime [CACHE_TIME] "Cache validity in seconds").default_value("3600"))
+        .arg(arg!(--cachetime [CACHE_TIME] "Cache validity in seconds for the authentication result").default_value("3600"))
         .get_matches();
 
     // Get the port from the command line arguments


### PR DESCRIPTION
This is now properly implemented, to test it:

1. Run the server with:

```shell
$ cargo run --color=always --package ya-mbtiles-server --bin ya-mbtiles-server --profile dev -- --authheaders Authorization
```

2. Open `index.html` and ensure it works
3. See the server logs contain:

```

[2024-12-08T16:22:52Z DEBUG ya_mbtiles_server::auth_middleware] Cache hit for Basic ..., valid for 3599 more seconds
```